### PR TITLE
Allow ID to be a number.

### DIFF
--- a/src/EventManager.js
+++ b/src/EventManager.js
@@ -522,6 +522,10 @@ function EventManager(options) { // assumed to be a calendar
 		}
 		
 		if (out.resources) {
+			if (typeof out.resources == 'number') {
+				out.resources = [out.resources];
+			}
+
 			if (typeof out.resources == 'string') {
 				out.resources = out.resources.split(/\s+/);
 			}


### PR DESCRIPTION
In typed world, we often use ID to associate to a resource.
At the moment, using an ID as a number does not work.

When I run the grunt command to update your files, it asks me to update a lot of files.
maybe there are some settings that are older?
